### PR TITLE
Fix blank notes field causing `undefined` to appear in listings

### DIFF
--- a/src/modules/ia/models/CopyrightProblemsListing.ts
+++ b/src/modules/ia/models/CopyrightProblemsListing.ts
@@ -118,17 +118,18 @@ export default class CopyrightProblemsListing {
 			// This ensures we're always using the prefixedDb version of the title (as
 			// provided by the anchor) for stability.
 			const prefixedDb = anchor.getAttribute( 'id' );
-			const href = el.getAttribute( 'href' );
 			const title = anchorToTitle( el as HTMLAnchorElement );
-            
-            if ( title === false ) {
-                // Not a valid link.
-                return false;
-            } else if ( title.getPrefixedText() !== new mw.Title( prefixedDb ).getPrefixedText() ) {
-                // Anchor and link mismatch. Someone tampered with the template?
-                // In this case, rely on the link instead, as the anchor is merely invisible.
-                console.warn( `Anchor and link mismatch for "${title.getPrefixedText()}".`, title, prefixedDb );
-            }
+
+			if ( title === false ) {
+				// Not a valid link.
+				return false;
+			} else if ( title.getPrefixedText() !== new mw.Title( prefixedDb ).getPrefixedText() ) {
+				// Anchor and link mismatch. Someone tampered with the template?
+				// In this case, rely on the link instead, as the anchor is merely invisible.
+				console.warn(
+					`Anchor and link mismatch for "${title.getPrefixedText()}".`, title, prefixedDb
+				);
+			}
 
 			// Checks for the <span class="plainlinks"> element.
 			// This ensures that the listing came from {{article-cv}} and isn't just a

--- a/src/modules/ia/ui/SinglePageWorkflowDialog.tsx
+++ b/src/modules/ia/ui/SinglePageWorkflowDialog.tsx
@@ -332,7 +332,7 @@ function initSinglePageWorkflowDialog() {
 					return;
 				}
 
-                this.data.fromUrls = selected;
+				this.data.fromUrls = selected;
 				fields.sourceUrls.toggle( selected );
 				fields.sourceText.toggle( !selected );
 			} );
@@ -341,7 +341,7 @@ function initSinglePageWorkflowDialog() {
 				this.data.sourceUrls = items.map( ( item ) => item.data );
 			} );
 			this.inputs.sourceText.on( 'change', ( text: string ) => {
-				this.data.sourceText = text.replace(/\.\s*$/, "");
+				this.data.sourceText = text.replace( /\.\s*$/, '' );
 			} );
 			fields.sourceText.toggle( false );
 
@@ -488,7 +488,7 @@ function initSinglePageWorkflowDialog() {
 			const comments = `${
 				( from || '' ).trim().length !== 0 ? 'from ' + from + '. ' : ''
 			}${
-				this.data.notes
+				this.data.notes ?? ''
 			}`;
 
 			await CopyrightProblemsPage.getCurrent()


### PR DESCRIPTION
See [Special:Diff/1111242074](https://en.wikipedia.org/w/index.php?title=Wikipedia:Copyright_problems/2022_September_20&oldid=1111242074) for an example. Blank and unmodified additional notes field leaves the data set to `undefined`, which is converted to a string because of template strings. This resolves that by checking to see if notes are set prior to actually saving the comment.