### PR TITLE
Add more environments to CI testing

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -78,7 +78,9 @@ jobs:
 
       - name: Install geckodriver
         if: matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
-        uses: ChlodAlejandro/setup-geckodriver@d1b6160d5ede35f95651c6cf0ca8d4fb4653b317
+        uses: ChlodAlejandro/setup-geckodriver@latest
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install chromedriver
         if: matrix.browser.product == 'chrome'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,7 +7,10 @@ on:
 jobs:
   build:
     name: Build Deputy
-    if: ${{ !contains(github.event.head_commit.message, '[failing]') }}
+    if: !contains(github.event.head_commit.message, '[failing]') || (
+        # browser-actions/setup-firefox does not support windows :/
+        matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -71,20 +74,23 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Firefox
-        # browser-actions/setup-firefox does not support windows :/
-        if: matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
+        if: matrix.browser.product == 'firefox'
         uses: browser-actions/setup-firefox@latest
         with:
           firefox-version: ${{ matrix.browser.version }}
 
       - name: Install geckodriver
-        # browser-actions/setup-firefox does not support windows :/
-        if: matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
+        if: matrix.browser.product == 'firefox'
         uses: browser-actions/setup-geckodriver@latest
 
       - name: Install chromedriver
         if: matrix.browser.product == 'chrome'
         uses: nanasess/setup-chromedriver@v1
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_ENV: production
 
       - name: Download transpiled code
         uses: actions/download-artifact@v3

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -13,16 +13,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ windows-latest, ubuntu-latest, macos-latest ]
-        browsers:
+        browser:
           # Chrome stable
           - product: chrome
             version: stable
-          # Chrome Beta
-          - product: chrome
-            version: beta
-          # Chrome Dev
-          - product: chrome
-            version: dev
           # Chrome Canary
           - product: chrome
             version: canary
@@ -34,9 +28,6 @@ jobs:
           - product: firefox
             version: latest
           # Firefox beta
-          - product: firefox
-            version: latest-beta
-          # Firefox dev edition
           - product: firefox
             version: latest-beta
           # Firefox ESR

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,6 +8,7 @@ jobs:
   build:
     name: Build Deputy
     if: ${{ !contains(github.event.head_commit.message, '[failing]') }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -35,6 +36,7 @@ jobs:
   tests:
     name: Perform tests
     if: ${{ !contains(github.event.head_commit.message, '[failing]') }}
+    needs: build
     strategy:
       max-parallel: 4
       fail-fast: false

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -80,6 +80,7 @@ jobs:
         if: matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
         uses: ChlodAlejandro/setup-geckodriver@latest
         with:
+          geckodriver-version: ${{ matrix.browser.version == '52.0' && '0.17.0' || 'latest' }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install chromedriver

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -111,3 +111,4 @@ jobs:
         run: npm run test:jest
         env:
           BROWSER: ${{ matrix.browser.product }}
+          BROWSER_VERSION: ${{ matrix.browser.version }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Install geckodriver
         if: matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
-        uses: browser-actions/setup-geckodriver@latest
+        uses: ChlodAlejandro/setup-geckodriver@latest
 
       - name: Install chromedriver
         if: matrix.browser.product == 'chrome'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,28 +7,61 @@ on:
 jobs:
   tests:
     name: Perform tests
-    runs-on: ubuntu-latest
     if: ${{ !contains(github.event.head_commit.message, '[failing]') }}
     strategy:
       max-parallel: 1
       fail-fast: false
       matrix:
-        product: [ 'chrome', 'firefox' ]
-
+        os: [ windows-latest, ubuntu-latest, macos-latest ]
+        browsers:
+          # Chrome stable
+          - product: chrome
+            version: stable
+          # Chrome Beta
+          - product: chrome
+            version: beta
+          # Chrome Dev
+          - product: chrome
+            version: dev
+          # Chrome Canary
+          - product: chrome
+            version: canary
+          # Chrome 79 (oldest supported by Browserslist string)
+          - product: chrome
+            version: '706915'
+            
+          # Firefox stable
+          - product: firefox
+            version: latest
+          # Firefox beta
+          - product: firefox
+            version: latest-beta
+          # Firefox dev edition
+          - product: firefox
+            version: latest-beta
+          # Firefox ESR
+          - product: firefox
+            version: latest-esr
+          # Firefox 52 (oldest supported by Browserslist string)
+          - product: firefox
+            version: '52.0'
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Firefox
-        if: matrix.product == 'firefox'
+        if: matrix.browser.product == 'firefox'
         uses: browser-actions/setup-firefox@latest
+        with:
+          firefox-version: ${{ matrix.browser.version }}
 
       - name: Install geckodriver
-        if: matrix.product == 'firefox'
+        if: matrix.browser.product == 'firefox'
         uses: browser-actions/setup-geckodriver@latest
 
       - name: Install chromedriver
-        if: matrix.product == 'chrome'
+        if: matrix.browser.product == 'chrome'
         uses: nanasess/setup-chromedriver@v1
 
       - name: Install dependencies
@@ -37,7 +70,7 @@ jobs:
       - name: Run tests
         run: npm run test
         env:
-          BROWSER: ${{ matrix.product }}
+          BROWSER: ${{ matrix.browser.product }}
 
       - name: Build
         run: npm run build

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -105,3 +105,9 @@ jobs:
         run: npm run test:jest
         env:
           BROWSER: ${{ matrix.browser.product }}
+
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-artifacts--${{ matrix.os }}-${{ matrix.browser.product }}-${{ matrix.browser.version }}
+          path: test/artifacts/*

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -110,4 +110,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-artifacts--${{ matrix.os }}-${{ matrix.browser.product }}-${{ matrix.browser.version }}
-          path: test/artifacts/*
+          path: tests/artifacts/*

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -32,12 +32,11 @@ jobs:
         with:
           name: sourcemaps
           path: build/*.js.map
-    
+
   tests:
     name: Perform tests
     needs: build
     strategy:
-      max-parallel: 4
       fail-fast: false
       matrix:
         os: [ windows-latest, ubuntu-latest, macos-latest ]
@@ -51,7 +50,7 @@ jobs:
           # Chrome 79 (oldest supported by Browserslist string)
           - product: chrome
             version: '706915'
-            
+
           # Firefox stable
           - product: firefox
             version: latest

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -89,7 +89,7 @@ jobs:
         if: matrix.browser.product != 'firefox' || matrix.os != 'windows-latest'
         run: npm ci
         env:
-          NODE_ENV: production
+          NODE_ENV: development
 
       - name: Download transpiled code
         if: matrix.browser.product != 'firefox' || matrix.os != 'windows-latest'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,11 +5,38 @@ on:
   pull_request:
 
 jobs:
+  build:
+    name: Build Deputy
+    if: ${{ !contains(github.event.head_commit.message, '[failing]') }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+        env:
+          NODE_ENV: production
+
+      - name: Upload transpiled code
+        uses: actions/upload-artifact@v3
+        with:
+          name: builds
+          path: build/*.js
+
+      - name: Upload sourcemaps
+        uses: actions/upload-artifact@v3
+        with:
+          name: sourcemaps
+          path: build/*.js.map
+    
   tests:
     name: Perform tests
     if: ${{ !contains(github.event.head_commit.message, '[failing]') }}
     strategy:
-      max-parallel: 1
+      max-parallel: 4
       fail-fast: false
       matrix:
         os: [ windows-latest, ubuntu-latest, macos-latest ]
@@ -55,34 +82,19 @@ jobs:
         if: matrix.browser.product == 'chrome'
         uses: nanasess/setup-chromedriver@v1
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run tests
-        run: npm run test
-        env:
-          BROWSER: ${{ matrix.browser.product }}
-
-      - name: Build
-        run: npm run build
-        env:
-          NODE_ENV: production
-
-      - name: Upload test artifacts
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: test-artifacts
-          path: tests/artifacts/*
-
-      - name: Upload transpiled code
-        uses: actions/upload-artifact@v3
+      - name: Download transpiled code
+        uses: actions/download-artifact@v3
         with:
           name: builds
-          path: build/*.js
+          path: build/
 
-      - name: Upload sourcemaps
-        uses: actions/upload-artifact@v3
+      - name: Download sourcemaps
+        uses: actions/download-artifact@v3
         with:
           name: sourcemaps
-          path: build/*.js.map
+          path: build/
+
+      - name: Run tests
+        run: npm run test:jest
+        env:
+          BROWSER: ${{ matrix.browser.product }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -35,9 +35,6 @@ jobs:
     
   tests:
     name: Perform tests
-    if: ${{ !contains(github.event.head_commit.message, '[failing]') || (
-        matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
-      ) }}
     needs: build
     strategy:
       max-parallel: 4
@@ -68,9 +65,17 @@ jobs:
           - product: firefox
             version: '52.0'
     runs-on: ${{ matrix.os }}
+    if: ${{ !contains(github.event.head_commit.message, '[failing]') }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        
+      - name: Ensure this isn't Windows + Firefox
+        if: ( matrix.browser.product == 'firefox' && matrix.os != 'windows-latest' )
+        uses: saulmaldonado/skip-workflow@v1
+        with:
+          phrase: '/^(\s\S)+$/g'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Firefox
         if: matrix.browser.product == 'firefox'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -47,9 +47,6 @@ jobs:
           # Chrome Canary
           - product: chrome
             version: canary
-          # Chrome 79 (oldest supported by Browserslist string)
-          - product: chrome
-            version: '706915'
 
           # Firefox stable
           - product: firefox
@@ -60,9 +57,6 @@ jobs:
           # Firefox ESR
           - product: firefox
             version: latest-esr
-          # Firefox 52 (oldest supported by Browserslist string)
-          - product: firefox
-            version: '52.0'
     runs-on: ${{ matrix.os }}
     if: ${{ !contains(github.event.head_commit.message, '[failing]') }}
     steps:
@@ -80,7 +74,6 @@ jobs:
         if: matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
         uses: ChlodAlejandro/setup-geckodriver@latest
         with:
-          geckodriver-version: ${{ matrix.browser.version == '52.0' && '0.16.0' || 'latest' }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install chromedriver
@@ -112,4 +105,3 @@ jobs:
         run: npm run test:jest
         env:
           BROWSER: ${{ matrix.browser.product }}
-          BROWSER_VERSION: ${{ matrix.browser.version }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,10 +7,7 @@ on:
 jobs:
   build:
     name: Build Deputy
-    if: !contains(github.event.head_commit.message, '[failing]') || (
-        # browser-actions/setup-firefox does not support windows :/
-        matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
-      )
+    if: ${{ !contains(github.event.head_commit.message, '[failing]') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -38,7 +35,9 @@ jobs:
     
   tests:
     name: Perform tests
-    if: ${{ !contains(github.event.head_commit.message, '[failing]') }}
+    if: ${{ !contains(github.event.head_commit.message, '[failing]') || (
+        matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
+      ) }}
     needs: build
     strategy:
       max-parallel: 4

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -71,13 +71,15 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Firefox
-        if: matrix.browser.product == 'firefox'
+        # browser-actions/setup-firefox does not support windows :/
+        if: matrix.browser.product == 'firefox' && matrix.os != "windows-latest"
         uses: browser-actions/setup-firefox@latest
         with:
           firefox-version: ${{ matrix.browser.version }}
 
       - name: Install geckodriver
-        if: matrix.browser.product == 'firefox'
+        # browser-actions/setup-firefox does not support windows :/
+        if: matrix.browser.product == 'firefox' && matrix.os != "windows-latest"
         uses: browser-actions/setup-geckodriver@latest
 
       - name: Install chromedriver

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -72,14 +72,14 @@ jobs:
 
       - name: Install Firefox
         # browser-actions/setup-firefox does not support windows :/
-        if: matrix.browser.product == 'firefox' && matrix.os != "windows-latest"
+        if: matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
         uses: browser-actions/setup-firefox@latest
         with:
           firefox-version: ${{ matrix.browser.version }}
 
       - name: Install geckodriver
         # browser-actions/setup-firefox does not support windows :/
-        if: matrix.browser.product == 'firefox' && matrix.os != "windows-latest"
+        if: matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
         uses: browser-actions/setup-geckodriver@latest
 
       - name: Install chromedriver

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Install geckodriver
         if: matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
-        uses: browser-actions/setup-geckodriver@latest
+        uses: ChlodAlejandro/setup-geckodriver@d1b6160d5ede35f95651c6cf0ca8d4fb4653b317
 
       - name: Install chromedriver
         if: matrix.browser.product == 'chrome'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -80,7 +80,7 @@ jobs:
         if: matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
         uses: ChlodAlejandro/setup-geckodriver@latest
         with:
-          geckodriver-version: ${{ matrix.browser.version == '52.0' && '0.17.0' || 'latest' }}
+          geckodriver-version: ${{ matrix.browser.version == '52.0' && '0.16.0' || 'latest' }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install chromedriver

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -68,7 +68,7 @@ jobs:
     if: ${{ !contains(github.event.head_commit.message, '[failing]') }}
     steps:
       - name: Checkout code
-        if: matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
+        if: matrix.browser.product != 'firefox' || matrix.os != 'windows-latest'
         uses: actions/checkout@v3
 
       - name: Install Firefox
@@ -86,27 +86,27 @@ jobs:
         uses: nanasess/setup-chromedriver@v1
 
       - name: Install dependencies
-        if: matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
+        if: matrix.browser.product != 'firefox' || matrix.os != 'windows-latest'
         run: npm ci
         env:
           NODE_ENV: production
 
       - name: Download transpiled code
-        if: matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
+        if: matrix.browser.product != 'firefox' || matrix.os != 'windows-latest'
         uses: actions/download-artifact@v3
         with:
           name: builds
           path: build/
 
       - name: Download sourcemaps
-        if: matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
+        if: matrix.browser.product != 'firefox' || matrix.os != 'windows-latest'
         uses: actions/download-artifact@v3
         with:
           name: sourcemaps
           path: build/
 
       - name: Run tests
-        if: matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
+        if: matrix.browser.product != 'firefox' || matrix.os != 'windows-latest'
         run: npm run test:jest
         env:
           BROWSER: ${{ matrix.browser.product }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Install geckodriver
         if: matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
-        uses: ChlodAlejandro/setup-geckodriver@latest
+        uses: browser-actions/setup-geckodriver@latest
 
       - name: Install chromedriver
         if: matrix.browser.product == 'chrome'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -68,23 +68,17 @@ jobs:
     if: ${{ !contains(github.event.head_commit.message, '[failing]') }}
     steps:
       - name: Checkout code
+        if: matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
         uses: actions/checkout@v3
-        
-      - name: Ensure this isn't Windows + Firefox
-        if: ( matrix.browser.product == 'firefox' && matrix.os == 'windows-latest' )
-        uses: saulmaldonado/skip-workflow@v1
-        with:
-          phrase: '/^(\s\S)+$/g'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Firefox
-        if: matrix.browser.product == 'firefox'
+        if: matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
         uses: browser-actions/setup-firefox@latest
         with:
           firefox-version: ${{ matrix.browser.version }}
 
       - name: Install geckodriver
-        if: matrix.browser.product == 'firefox'
+        if: matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
         uses: browser-actions/setup-geckodriver@latest
 
       - name: Install chromedriver
@@ -92,23 +86,27 @@ jobs:
         uses: nanasess/setup-chromedriver@v1
 
       - name: Install dependencies
+        if: matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
         run: npm ci
         env:
           NODE_ENV: production
 
       - name: Download transpiled code
+        if: matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
         uses: actions/download-artifact@v3
         with:
           name: builds
           path: build/
 
       - name: Download sourcemaps
+        if: matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
         uses: actions/download-artifact@v3
         with:
           name: sourcemaps
           path: build/
 
       - name: Run tests
+        if: matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
         run: npm run test:jest
         env:
           BROWSER: ${{ matrix.browser.product }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v3
         
       - name: Ensure this isn't Windows + Firefox
-        if: ( matrix.browser.product == 'firefox' && matrix.os != 'windows-latest' )
+        if: ( matrix.browser.product == 'firefox' && matrix.os == 'windows-latest' )
         uses: saulmaldonado/skip-workflow@v1
         with:
           phrase: '/^(\s\S)+$/g'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "version": "0.2.0",
     "main": "src/deputy.js",
     "scripts": {
-        "test": "npm run build && jest",
+        "test": "npm run build && npm run test:jest",
+        "test:jest": "jest",
         "version": "node scripts/sync-version.js && git add src/DeputyVersion.ts",
         "clean": "shx rm -rf build .rollup.cache",
         "prebuild": "shx mkdir -p build/i18n/ && shx cp -Rf i18n/* build/i18n/",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "version": "0.2.0",
     "main": "src/deputy.js",
     "scripts": {
-        "test": "npm run build && npm run test:jest",
+        "test": "npm run build && npm run test:clean && npm run test:jest",
+        "test:clean": "shx rm -rf tests/artifacts/ && shx mkdir -p tests/artifacts/",
         "test:jest": "jest",
         "version": "node scripts/sync-version.js && git add src/DeputyVersion.ts",
         "clean": "shx rm -rf build .rollup.cache",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "which": "^2.0.2"
     },
     "browserslist": [
-        "cover 95% and not IE 11 and supports fetch"
+        ">0.05% and supports fetch and not dead"
     ],
     "dependencies": {
         "@chlodalejandro/parsoid": "2.0.0-f08be30",

--- a/tests/util/BrowserHelper.ts
+++ b/tests/util/BrowserHelper.ts
@@ -28,22 +28,7 @@ export default class BrowserHelper extends webdriver.WebDriver {
 			chromeOpts.headless();
 
 			if ( browser === 'firefox' ) {
-
-				const browserVersion = process.env.BROWSER_VERSION || await ( async () => {
-					console.log( 'Browser version not specified. Will attempt to guess ' +
-						'(browser may open momentarily).' );
-					return await new webdriver.Builder()
-						.forBrowser( 'firefox' )
-						.build()
-						.then( async ( d ) => {
-							const v = d.getCapabilities().then( c => c.getBrowserVersion() );
-							await d.close();
-							return v;
-						} );
-				} )();
-				if ( +( /^(\d+)\./.exec( browserVersion )?.[ 1 ] ?? '56' ) > 55 ) {
-					firefoxOpts.headless();
-				}
+				firefoxOpts.headless();
 			}
 		}
 

--- a/tests/util/BrowserHelper.ts
+++ b/tests/util/BrowserHelper.ts
@@ -13,6 +13,8 @@ import WebDriverError = error.WebDriverError;
  */
 export default class BrowserHelper extends webdriver.WebDriver {
 
+	static readonly artifactFolder = path.resolve( __dirname, '..', 'artifacts' );
+
 	/**
 	 * Builds a BrowserHelper.
 	 */
@@ -52,8 +54,12 @@ export default class BrowserHelper extends webdriver.WebDriver {
 		const logStreams: Record<string, WriteStream> = {};
 		try {
 			for ( const stream of await driver.manage().logs().getAvailableLogTypes() ) {
+				if ( fs.stat( BrowserHelper.artifactFolder ).catch( () => false ) ) {
+					await fs.mkdir( BrowserHelper.artifactFolder, { recursive: true } );
+				}
+
 				logStreams[ stream ] = ( await fs.open(
-					path.join( __dirname, '..', 'artifacts', `selenium-${
+					path.join( BrowserHelper.artifactFolder, `selenium-${
 						stream.toLowerCase()
 					}.log` ), 'a'
 				) ).createWriteStream();

--- a/tests/util/BrowserHelper.ts
+++ b/tests/util/BrowserHelper.ts
@@ -29,12 +29,19 @@ export default class BrowserHelper extends webdriver.WebDriver {
 
 			if ( browser === 'firefox' ) {
 
-				const firefoxDriver = await new webdriver.Builder()
-					.forBrowser( 'firefox' )
-					.build();
-				if ( +( /^(\d+)\./.exec(
-					( await firefoxDriver.getCapabilities() ).getBrowserVersion()
-				) ) > 55 ) {
+				const browserVersion = process.env.BROWSER_VERSION || await ( async () => {
+					console.log( 'Browser version not specified. Will attempt to guess ' +
+						'(browser may open momentarily).' );
+					return await new webdriver.Builder()
+						.forBrowser( 'firefox' )
+						.build()
+						.then( async ( d ) => {
+							const v = d.getCapabilities().then( c => c.getBrowserVersion() );
+							await d.close();
+							return v;
+						} );
+				} )();
+				if ( +( /^(\d+)\./.exec( browserVersion )[ 1 ] ?? '56' ) > 55 ) {
 					firefoxOpts.headless();
 				}
 			}

--- a/tests/util/BrowserHelper.ts
+++ b/tests/util/BrowserHelper.ts
@@ -41,7 +41,7 @@ export default class BrowserHelper extends webdriver.WebDriver {
 							return v;
 						} );
 				} )();
-				if ( +( /^(\d+)\./.exec( browserVersion )[ 1 ] ?? '56' ) > 55 ) {
+				if ( +( /^(\d+)\./.exec( browserVersion )?.[ 1 ] ?? '56' ) > 55 ) {
 					firefoxOpts.headless();
 				}
 			}

--- a/tests/util/BrowserHelper.ts
+++ b/tests/util/BrowserHelper.ts
@@ -59,7 +59,7 @@ export default class BrowserHelper extends webdriver.WebDriver {
 				) ).createWriteStream();
 			}
 		} catch ( e ) {
-			console.warn( 'Browser does not support logs. Going in blind.' );
+			console.warn( 'Browser does not support logs. Going in blind.', e );
 		}
 
 		return new BrowserHelper( driver.getSession(), driver.getExecutor(), logStreams );


### PR DESCRIPTION
Currently does not support Firefox+Windows due to a quirk. Otherwise, this enables testing on Chrome and Firefox for Windows, macOS, and Ubuntu.