### PR TITLE
Enable Windows support in CI tests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -73,17 +73,16 @@ jobs:
     if: ${{ !contains(github.event.head_commit.message, '[failing]') }}
     steps:
       - name: Checkout code
-        if: matrix.browser.product != 'firefox' || matrix.os != 'windows-latest'
         uses: actions/checkout@v3
 
       - name: Install Firefox
-        if: matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
+        if: matrix.browser.product == 'firefox'
         uses: browser-actions/setup-firefox@latest
         with:
           firefox-version: ${{ matrix.browser.version }}
 
       - name: Install geckodriver
-        if: matrix.browser.product == 'firefox' && matrix.os != 'windows-latest'
+        if: matrix.browser.product == 'firefox'
         uses: browser-actions/setup-geckodriver@latest
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -99,27 +98,23 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        if: matrix.browser.product != 'firefox' || matrix.os != 'windows-latest'
         run: npm ci
         env:
           NODE_ENV: development
 
       - name: Download transpiled code
-        if: matrix.browser.product != 'firefox' || matrix.os != 'windows-latest'
         uses: actions/download-artifact@v3
         with:
           name: builds
           path: build/
 
       - name: Download sourcemaps
-        if: matrix.browser.product != 'firefox' || matrix.os != 'windows-latest'
         uses: actions/download-artifact@v3
         with:
           name: sourcemaps
           path: build/
 
       - name: Run tests
-        if: matrix.browser.product != 'firefox' || matrix.os != 'windows-latest'
         run: npm run test:jest
         env:
           BROWSER: ${{ matrix.browser.product }}


### PR DESCRIPTION
Windows CI support is currently disabled in the upstream [`browser-actions/setup-firefox`](https://github.com/browser-actions/setup-firefox) action. This re-enables Windows CI support when the upstream PR (browser-actions/setup-firefox#422) has been closed.